### PR TITLE
Avoid MSVC compiler warning of local shadowing a member variable

### DIFF
--- a/asyncfuture.h
+++ b/asyncfuture.h
@@ -643,10 +643,10 @@ public:
         // Used internally for linking to the context object.
         // weakRef is used because we don't want the long lived context object to keep
         // deferred alive.
-        auto weakRef = this->weakRef;
+        auto weakRef_ = this->weakRef;
         QObject::connect(sender, member,
-                         this, [weakRef]() {
-            auto self = weakRef.toStrongRef();
+                         this, [weakRef_]() {
+            auto self = weakRef_.toStrongRef();
             if (!self.isNull()) {
                 self->cancel();
             }


### PR DESCRIPTION
I get a compiler warning with Qt5 (5.15.7) and MSVC 19.16.27050.0.

The `weakRef` variable in `DeferredFuture::cancel(const QObject* sender, Member member)` is found to shadow the member field `this->weakRef`.

This commit changes the variable change to avoid the warning.